### PR TITLE
fix the status bar bug

### DIFF
--- a/client/src/StatusController.ts
+++ b/client/src/StatusController.ts
@@ -57,7 +57,7 @@ export class StatusController {
                 break;
         }
 
-        if (!statusValue || statusValue === CheckStatus.wait) {
+        if (statusValue === undefined || statusValue === CheckStatus.wait) {
             this._statusbar.command = 'checkstyle.checkCodeWithCheckstyle';
             this._statusbar.tooltip = 'Check code with Checkstyle';
         } else {


### PR DESCRIPTION
Fix #99 

Root cause: 
What we need here is check if the status is `undefined`, but the value of `CheckStatus.success` is 0, so it become true after `! statusValue `