### PR TITLE
Add status bar

### DIFF
--- a/src/checkstyleDiagnosticCollector.ts
+++ b/src/checkstyleDiagnosticCollector.ts
@@ -12,9 +12,6 @@ class CheckstyleDiagnosticCollector implements Disposable {
     }
 
     public addDiagnostics(uri: Uri, violations: ICheckstyleResult[]): void {
-        if (violations.length === 0) {
-            return;
-        }
         const diagnostics: Diagnostic[] = [];
         for (const violation of violations) {
             const startLine: number = Math.max(violation.line - 1, 0);
@@ -28,6 +25,10 @@ class CheckstyleDiagnosticCollector implements Disposable {
             });
         }
         this.diagnosticCollection.set(uri, diagnostics);
+    }
+
+    public getDiagnostics(uri: Uri): Diagnostic[] | undefined {
+        return this.diagnosticCollection.get(uri);
     }
 
     public delete(uri: Uri): void {

--- a/src/checkstyleStatusBar.ts
+++ b/src/checkstyleStatusBar.ts
@@ -26,7 +26,7 @@ class CheckstyleStatusBar implements Disposable {
         }
 
         this.statusBar.text = diagnostics.length !== 0 ? '$(bug)' : '$(check)';
-        this.statusBar.tooltip = `[Checkstyle] ${diagnostics.length} violation${diagnostics.length > 1 ? 's' : ''} found`;
+        this.statusBar.tooltip = `[Checkstyle] ${diagnostics.length} violation${diagnostics.length === 1 ? '' : 's'} found`;
         this.statusBar.show();
     }
 

--- a/src/checkstyleStatusBar.ts
+++ b/src/checkstyleStatusBar.ts
@@ -1,0 +1,51 @@
+// Copyright (c) jdneo. All rights reserved.
+// Licensed under the GNU LGPLv3 license.
+
+import { Diagnostic, Disposable, StatusBarAlignment, StatusBarItem, window } from 'vscode';
+import { checkstyleDiagnosticCollector } from './checkstyleDiagnosticCollector';
+import { CheckstyleExtensionCommands } from './constants/commands';
+
+class CheckstyleStatusBar implements Disposable {
+    private statusBar: StatusBarItem;
+
+    constructor() {
+        this.statusBar = window.createStatusBarItem(StatusBarAlignment.Right);
+        this.statusBar.show();
+    }
+
+    public showStatus(): void {
+        if (!window.activeTextEditor) {
+            this.statusBar.hide();
+            return;
+        }
+        this.clearStatus();
+        const diagnostics: Diagnostic[] | undefined = checkstyleDiagnosticCollector.getDiagnostics(window.activeTextEditor.document.uri);
+        if (!diagnostics) {
+            this.statusBar.hide();
+            return;
+        }
+
+        this.statusBar.text = diagnostics.length !== 0 ? '$(bug)' : '$(check)';
+        this.statusBar.tooltip = `[Checkstyle] ${diagnostics.length} violation${diagnostics.length > 1 ? 's' : ''} found`;
+        this.statusBar.show();
+    }
+
+    public showError(): void {
+        this.statusBar.text = '$(stop)';
+        this.statusBar.tooltip = `[Checkstyle] Internal error occurred`;
+        this.statusBar.command = CheckstyleExtensionCommands.OPEN_OUTPUT_CHANNEL;
+        this.statusBar.show();
+    }
+
+    public dispose(): void {
+        this.statusBar.dispose();
+    }
+
+    private clearStatus(): void {
+        this.statusBar.command = undefined;
+        this.statusBar.text = '';
+        this.statusBar.tooltip = undefined;
+    }
+}
+
+export const checkstyleStatusBar: CheckstyleStatusBar = new CheckstyleStatusBar();

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { Uri, window } from 'vscode';
 import { checkstyleChannel } from '../checkstyleChannel';
 import { checkstyleDiagnosticCollector } from '../checkstyleDiagnosticCollector';
+import { checkstyleStatusBar } from '../checkstyleStatusBar';
 import { BuiltinConfiguration } from '../constants/BuiltinConfiguration';
 import { CheckstyleExtensionCommands } from '../constants/commands';
 import { ICheckstyleResult } from '../models';
@@ -45,6 +46,7 @@ export async function checkstyle(uri?: Uri): Promise<void> {
             return;
         }
         checkstyleDiagnosticCollector.addDiagnostics(uri, results);
+        checkstyleStatusBar.showStatus();
     } catch (error) {
         handleErrors(error);
     }

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -9,6 +9,7 @@ export namespace CheckstyleExtensionCommands {
     export const SET_CHECKSTYLE_CONFIGURATION: string = 'java.checkstyle.set.configuration';
     export const CHECK_CODE_WITH_CHECKSTYLE: string = 'java.checkstyle.checkcode';
     export const FIX_CHECKSTYLE_VIOLATION: string = 'java.checkstyle.quickfix';
+    export const OPEN_OUTPUT_CHANNEL: string = 'java.checkstyle.open.output.channel';
 }
 
 export namespace VsCodeCommands {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,13 +5,13 @@ import { ExtensionContext, FileSystemWatcher, languages, TextEditor, Uri, window
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation, instrumentOperationAsVsCodeCommand } from 'vscode-extension-telemetry-wrapper';
 import { checkstyleChannel } from './checkstyleChannel';
 import { checkstyleDiagnosticCollector } from './checkstyleDiagnosticCollector';
+import { checkstyleStatusBar } from './checkstyleStatusBar';
 import { checkstyle } from './commands/check';
 import { fixCheckstyleViolation } from './commands/fix';
 import { setCheckstyleConfiguration } from './commands/setCheckstyleConfiguration';
 import { CheckstyleExtensionCommands } from './constants/commands';
 import { quickFixProvider } from './quickFixProvider';
 import { isAutoCheckEnabled } from './utils/settingUtils';
-import { checkstyleStatusBar } from './checkstyleStatusBar';
 
 export async function activate(context: ExtensionContext): Promise<void> {
     await initializeFromJsonFile(context.asAbsolutePath('./package.json'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { setCheckstyleConfiguration } from './commands/setCheckstyleConfiguratio
 import { CheckstyleExtensionCommands } from './constants/commands';
 import { quickFixProvider } from './quickFixProvider';
 import { isAutoCheckEnabled } from './utils/settingUtils';
+import { checkstyleStatusBar } from './checkstyleStatusBar';
 
 export async function activate(context: ExtensionContext): Promise<void> {
     await initializeFromJsonFile(context.asAbsolutePath('./package.json'));
@@ -45,6 +46,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
 
     context.subscriptions.push(
         checkstyleChannel,
+        checkstyleStatusBar,
         watcher,
         languages.registerCodeActionsProvider({ scheme: 'file', language: 'java' }, quickFixProvider),
         instrumentOperationAsVsCodeCommand(CheckstyleExtensionCommands.OPEN_OUTPUT_CHANNEL, () => checkstyleChannel.show()),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         checkstyleChannel,
         watcher,
         languages.registerCodeActionsProvider({ scheme: 'file', language: 'java' }, quickFixProvider),
+        instrumentOperationAsVsCodeCommand(CheckstyleExtensionCommands.OPEN_OUTPUT_CHANNEL, () => checkstyleChannel.show()),
         instrumentOperationAsVsCodeCommand(CheckstyleExtensionCommands.SET_CHECKSTYLE_CONFIGURATION, async (uri?: Uri) => await setCheckstyleConfiguration(uri)),
         instrumentOperationAsVsCodeCommand(CheckstyleExtensionCommands.CHECK_CODE_WITH_CHECKSTYLE, async (uri?: Uri) => await checkstyle(uri)),
         instrumentOperationAsVsCodeCommand(CheckstyleExtensionCommands.FIX_CHECKSTYLE_VIOLATION, async (uri: Uri, offset: number, sourceName: string) => await fixCheckstyleViolation(uri, offset, sourceName)),

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,12 +1,8 @@
 // Copyright (c) jdneo. All rights reserved.
 // Licensed under the GNU LGPLv3 license.
 
-import { commands, Uri, window } from 'vscode';
 import { checkstyleChannel } from '../checkstyleChannel';
-import { VsCodeCommands } from '../constants/commands';
-
-const OPEN: string = 'Open';
-const REPORT_ISSUE: string = 'Report Issue';
+import { checkstyleStatusBar } from '../checkstyleStatusBar';
 
 export async function handleErrors(error: Error): Promise<void> {
     if (error['data']) {
@@ -14,12 +10,6 @@ export async function handleErrors(error: Error): Promise<void> {
     } else {
         checkstyleChannel.appendLine(error.toString());
     }
-    const choice: string | undefined = await window.showErrorMessage('Unexpected exception occurred, please open the Checkstyle output channel for details.', OPEN, REPORT_ISSUE);
-    if (!choice) {
-        return;
-    } else if (choice === OPEN) {
-        checkstyleChannel.show();
-    } else if (choice === REPORT_ISSUE) {
-        commands.executeCommand(VsCodeCommands.OPEN, Uri.parse('https://aka.ms/vscode-checkstyle-issue'));
-    }
+
+    checkstyleStatusBar.showError();
 }


### PR DESCRIPTION
Fix #155

Instead of keep popping up a dialog to the user. We use the status bar to show the current status of the Checkstyle.

- If no violation, it will show a check
- If having violation(s), it will show a bug
- If an internal error occurs, it will show a stop sign. If the user clicks on the stop sign, we will open the output channel.