### PR TITLE
Fix workspaceFolder regex | Add configuration file path to error message 

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -34,7 +34,8 @@ export async function checkstyle(uri?: Uri): Promise<void> {
         return;
     }
     if (!isBuiltinConfiguration(configurationPath) && !await fse.pathExists(configurationPath)) {
-        window.showErrorMessage('The following Checkstyle configuration file does not exist. Please make sure it is set correctly.', configurationPath);
+        window.showErrorMessage('The following Checkstyle configuration file does not exist. Please make sure it is set correctly.',
+                                configurationPath);
         return;
     }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -34,7 +34,7 @@ export async function checkstyle(uri?: Uri): Promise<void> {
         return;
     }
     if (!isBuiltinConfiguration(configurationPath) && !await fse.pathExists(configurationPath)) {
-        window.showErrorMessage('The Checkstyle configuration file does not exist. Please make sure it is set correctly.');
+        window.showErrorMessage('The following Checkstyle configuration file does not exist. Please make sure it is set correctly.', configurationPath);
         return;
     }
 

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -25,7 +25,7 @@ export function setCheckstyleConfigurationPath(fsPath: string, uri?: Uri): void 
     setConfiguration(JAVA_CHECKSTYLE_CONFIGURATION, fsPath, uri);
 }
 
-const workspaceRegexp: RegExp = /\$\{workspacefolder\}/i;
+const workspaceRegexp: RegExp = /\$\{workspaceFolder\}/i;
 function resolveVariables(resourceUri: Uri, value: string): string {
     const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(resourceUri);
     if (!workspaceFolder) {


### PR DESCRIPTION
- The path check now uses the right regex (`workspaceFolder` instead of `workspacefolder`)
- The path of the configuration file is now part of the error message if it is not found.

Related to #174