### PR TITLE
Improved error handling

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/META-INF/MANIFEST.MF
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Import-Package: org.eclipse.jdt.core,
  org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.jdt.core,
+ org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j,
  org.eclipse.jdt.launching,
  org.eclipse.jdt.ls.core,

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/CheckstyleResponseErrorCode.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/CheckstyleResponseErrorCode.java
@@ -1,0 +1,16 @@
+package com.shengchen.checkstyle.runner.exceptions;
+
+public enum CheckstyleResponseErrorCode {
+    
+    UnsupportedQuickfix(-39001);
+    
+    private final int value;
+    
+    CheckstyleResponseErrorCode(int value) {
+        this.value = value;
+    }
+    
+    public int getValue() {
+        return value;
+    }
+}

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/CheckstyleResponseErrorException.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/CheckstyleResponseErrorException.java
@@ -1,0 +1,12 @@
+package com.shengchen.checkstyle.runner.exceptions;
+
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+
+public class CheckstyleResponseErrorException extends ResponseErrorException {
+
+    public CheckstyleResponseErrorException(CheckstyleResponseErrorCode code, String message) {
+        super(new ResponseError(code.getValue(), message, null));
+    }
+
+}

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/UnsupportedQuickfixException.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/exceptions/UnsupportedQuickfixException.java
@@ -1,0 +1,9 @@
+package com.shengchen.checkstyle.runner.exceptions;
+
+public class UnsupportedQuickfixException extends CheckstyleResponseErrorException {
+
+    public UnsupportedQuickfixException(String sourceName) {
+        super(CheckstyleResponseErrorCode.UnsupportedQuickfix, sourceName);
+    }
+
+}

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/handler/DelegateCommandHandler.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/handler/DelegateCommandHandler.java
@@ -17,11 +17,17 @@
 
 package com.shengchen.checkstyle.runner.handler;
 
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.shengchen.checkstyle.runner.CheckstyleRunner;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.IDelegateCommandHandler;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @SuppressWarnings("restriction")
@@ -31,14 +37,41 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
     private static final String FIX_CHECKSTYLE_VIOLATION = "java.checkstyle.quickfix";
 
     @Override
-    public Object executeCommand(String commandId, List<Object> arguments, IProgressMonitor monitor) throws Exception {
-        switch (commandId) {
-            case CHECK_CODE_WITH_CHECKSTYLE:
-                return CheckstyleRunner.check(arguments);
-            case FIX_CHECKSTYLE_VIOLATION:
-                return CheckstyleRunner.quickFix(arguments);
+    public Object executeCommand(String commandId, List<Object> arguments, IProgressMonitor monitor)
+            throws ResponseErrorException {
+        try {
+            switch (commandId) {
+                case CHECK_CODE_WITH_CHECKSTYLE:
+                    return CheckstyleRunner.check(arguments);
+                case FIX_CHECKSTYLE_VIOLATION:
+                    return CheckstyleRunner.quickFix(arguments);
+                default:
+                    throw new ResponseErrorException(
+                            new ResponseError(ResponseErrorCode.MethodNotFound, "Unknown command", commandId));
+            }
+        } catch (Throwable ex) {
+            throw asResponseException(ex, commandId, arguments);
+            // throw new ResponseErrorException(new ResponseError(-32123, "Emmm", null));
         }
-        return null;
     }
 
+    private ResponseErrorException asResponseException(Throwable ex, String commandId, List<Object> arguments) {
+        if (ex instanceof ResponseErrorException) {
+            return (ResponseErrorException) ex;
+        }
+        if (ex instanceof IllegalArgumentException) {
+            return new ResponseErrorException(
+                    new ResponseError(ResponseErrorCode.InvalidParams, ex.getMessage(), arguments));
+        }
+        if (ex instanceof CheckstyleException) {
+            return new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidRequest, ex.getMessage(), ex));
+        }
+        if (ex instanceof UnsupportedEncodingException) {
+            return new ResponseErrorException(new ResponseError(ResponseErrorCode.ParseError, ex.getMessage(), ex));
+        }
+        if (ex instanceof RuntimeException || ex instanceof CoreException) {
+            return new ResponseErrorException(new ResponseError(ResponseErrorCode.InternalError, ex.getMessage(), ex));
+        }
+        return new ResponseErrorException(new ResponseError(ResponseErrorCode.UnknownErrorCode, ex.getMessage(), ex));
+    }
 }

--- a/src/commands/executeJavaLanguageServerCommand.ts
+++ b/src/commands/executeJavaLanguageServerCommand.ts
@@ -2,8 +2,10 @@
 // Licensed under the GNU LGPLv3 license.
 
 import { commands } from 'vscode';
+import { checkstyleChannel } from '../checkstyleChannel';
 import { JavaLanguageServerCommands } from '../constants/commands';
 
 export function executeJavaLanguageServerCommand<T>(...args: any[]): Thenable<T | undefined> {
+    checkstyleChannel.appendLine(`[Info] Executing command: ${JSON.stringify({ id: args[0], arguments: args.slice(1) })}`);
     return commands.executeCommand<T>(JavaLanguageServerCommands.EXECUTE_WORKSPACE_COMMAND, ...args);
 }

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,15 +1,46 @@
 // Copyright (c) jdneo. All rights reserved.
 // Licensed under the GNU LGPLv3 license.
 
+import { window } from 'vscode';
+import { ErrorCodes, ResponseError } from 'vscode-languageserver-protocol';
 import { checkstyleChannel } from '../checkstyleChannel';
 import { checkstyleStatusBar } from '../checkstyleStatusBar';
 
-export async function handleErrors(error: Error): Promise<void> {
-    if (error['data']) {
-        checkstyleChannel.appendLine(JSON.stringify(error['data']));
-    } else {
-        checkstyleChannel.appendLine(error.toString());
-    }
+export enum CheckstyleErrorCodes {
+    UnsupportedQuickfix = -39001,
+}
 
+export async function handleErrors(error: Error): Promise<void> {
+    if ('code' in error && 'data' in error) {
+        handleResponseErrors(error as ResponseError<any>);
+    } else {
+        checkstyleChannel.appendLine(`[Extension Error] ${error}`);
+    }
     checkstyleStatusBar.showError();
+}
+
+async function handleResponseErrors(error: ResponseError<any>): Promise<void> {
+    switch (error.code) {
+        case CheckstyleErrorCodes.UnsupportedQuickfix:
+            checkstyleChannel.appendLine(`[Checkstyle Error] Unsupported quickfix: ${error.message}`);
+            break;
+        case ErrorCodes.InvalidRequest:
+            checkstyleChannel.appendLine(`[Checkstyle Error] ${error.message}`);
+            window.showErrorMessage(`Checkstyle: ${error.message}`);
+            break;
+        case ErrorCodes.MethodNotFound:
+            checkstyleChannel.appendLine(`[Command Error] Invalid command: ${error.message}`);
+            break;
+        case ErrorCodes.InvalidParams:
+            checkstyleChannel.appendLine(`[Command Error] Invalid command arguments: ${JSON.stringify({
+                message: error.message,
+                arguments: JSON.stringify(error.data),
+            }, undefined, 2)}`);
+            break;
+        case ErrorCodes.InternalError:
+        case ErrorCodes.UnknownErrorCode:
+        default:
+            checkstyleChannel.appendLine(`[Server Error] ${error.message}\n${JSON.stringify(error.data, undefined, 2)}`);
+            window.showErrorMessage('Internal server error occured, please open output channel for detail.');
+    }
 }


### PR DESCRIPTION
## Abstract

This PR introduces an improved way of handling errors from java language server's response, based on the ResponseError mechanism of lsp and json-rpc.

## Introduction

When executing VS Code's `java.execute.workspaceCommand` command, it will send a request to java language server, then wait for the response result or error.

The layout of error object conforms to the [specification of language server protocal](), which uses error code to indicate the type of error:

```ts
export namespace ErrorCodes {
	// Defined by JSON RPC
	export const ParseError: number = -32700;
	export const InvalidRequest: number = -32600;
	export const MethodNotFound: number = -32601;
	export const InvalidParams: number = -32602;
	export const InternalError: number = -32603;
	export const serverErrorStart: number = -32099;
	export const serverErrorEnd: number = -32000;
	export const ServerNotInitialized: number = -32002;
	export const UnknownErrorCode: number = -32001;

	// Defined by the protocol.
	export const RequestCancelled: number = -32800;
	export const ContentModified: number = -32801;
}
```

The first section of error codes derive form the [specification of json-rpc](https://www.jsonrpc.org/specification), it also stated that
> The remainder of the space is available for application defined errors.

So, we could reuse the error code field here, to define our own error code related to checkstyle, e.g.:
```java
public enum CheckstyleResponseErrorCode {
    
    UnsupportedQuickfix(-39001);
    
    private final int value;
    
    CheckstyleResponseErrorCode(int value) {
        this.value = value;
    }
    
    public int getValue() {
        return value;
    }
}
```
and
```ts
export enum CheckstyleErrorCodes {
    UnsupportedQuickfix = -39001,
}
```
Defines an error that the quickfix type is unsupported.

## Details

How will java language server return an json will error field conforms to our design? Investigate into the source code, we could find the strategy [here](https://github.com/eclipse/eclipse.jdt.ls/blob/4bf992e9c686c90337665ebc5d4052ed7e0357cd/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler.java#L217):

```java
public void handleException(Throwable ex) {
    IStatus status = new Status(IStatus.ERROR, IConstants.PLUGIN_ID, IStatus.OK, "Error in calling delegate command handler", ex);
    JavaLanguageServerPlugin.log(status);
    if (ex instanceof ResponseErrorException) {
        throw (ResponseErrorException) ex;
    }
    throw new ResponseErrorException(new ResponseError(ResponseErrorCode.UnknownErrorCode, ex.getMessage(), ex));
}
```
If the caught exception is `ResponseErrorException`, language server will directly throw it, and an related error json is thus created. All other exceptions will be wrapped as `ResponseErrorException` will error code `Unkonwn`.

So, we could:
1. Create a `CheckstyleResponseErrorException` class that subclasses `ResponseErrorException`, and define our own error code.
2. Wrap all other exceptions thrown from the checkstyle plugin as `ResponseErrorException`, and give it a meaningful error code.

From the typescript extension side, we could then do the corresponding handling according to the error code received.