### PR TITLE
Supports loading checkstyle config via http url

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,13 +1,11 @@
 // Copyright (c) jdneo. All rights reserved.
 // Licensed under the GNU LGPLv3 license.
 
-import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Uri, window } from 'vscode';
 import { checkstyleChannel } from '../checkstyleChannel';
 import { checkstyleDiagnosticCollector } from '../checkstyleDiagnosticCollector';
 import { checkstyleStatusBar } from '../checkstyleStatusBar';
-import { BuiltinConfiguration } from '../constants/BuiltinConfiguration';
 import { CheckstyleExtensionCommands } from '../constants/commands';
 import { ICheckstyleResult } from '../models';
 import { handleErrors } from '../utils/errorUtils';
@@ -33,10 +31,6 @@ export async function checkstyle(uri?: Uri): Promise<void> {
         checkstyleChannel.appendLine('Checkstyle configuration file not set yet, skip the check.');
         return;
     }
-    if (!isBuiltinConfiguration(configurationPath) && !await fse.pathExists(configurationPath)) {
-        window.showErrorMessage('The Checkstyle configuration file does not exist. Please make sure it is set correctly.');
-        return;
-    }
 
     try {
         const results: ICheckstyleResult[] | undefined = await executeJavaLanguageServerCommand<ICheckstyleResult[]>(
@@ -50,8 +44,4 @@ export async function checkstyle(uri?: Uri): Promise<void> {
     } catch (error) {
         handleErrors(error);
     }
-}
-
-function isBuiltinConfiguration(config: string): boolean {
-    return config === BuiltinConfiguration.GoogleCheck || config === BuiltinConfiguration.SunCheck;
 }


### PR DESCRIPTION
## Abstract
Fix #181 

## Introduction

To support loading checkstyle config via http url, we only need to remove the path checking in ts extension side.

Clarification:
1. Checkstyle‘s [`LoadConfiguration`](https://github.com/checkstyle/checkstyle/blob/2a54aad3f3cf01d98940a4ea86500fff3af3cce2/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java#L392) method already supports loading via a http URL:
```java
loadConfiguration(String config, ...) {
        // figure out if this is a File or a URL
        final URI uri = CommonUtil.getUriByFilename(config);
        final InputSource source = new InputSource(uri.toString());
        return loadConfiguration(source, overridePropsResolver,
                ignoredModulesOptions, threadModeSettings);
}
```
2. Checkstyle already provided a [path checking logic](https://github.com/checkstyle/checkstyle/blob/9b8dea47d8a636905071e962675a644f8c5ba351/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java#L519), we don't need to maintain another one in ts extension side. If the url is invalid, an `CheckStyleException` will be thrown:

```java
try {
    final URL configUrl;
    if (filename.charAt(0) == '/') {
        configUrl = CommonUtil.class.getResource(filename);
    }
    else {
        configUrl = ClassLoader.getSystemResource(filename);
    }
    if (configUrl == null) {
        throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename);
    }
    uri = configUrl.toURI();
}
catch (final URISyntaxException ex) {
    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
}
```

