### PR TITLE
perf: Static checker in Java server

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/plugin.xml
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/plugin.xml
@@ -3,9 +3,9 @@
 <plugin>
   <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
     <delegateCommandHandler class="com.shengchen.checkstyle.runner.handler.DelegateCommandHandler">
-    	<command id="java.checkstyle.setConfiguration"/>
+      <command id="java.checkstyle.setConfiguration"/>
       <command id="java.checkstyle.checkCode"/>
-    	<command id="java.checkstyle.quickFix"/>
+      <command id="java.checkstyle.quickFix"/>
     </delegateCommandHandler>
   </extension>
 </plugin>

--- a/jdtls.ext/com.shengchen.checkstyle.runner/plugin.xml
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/plugin.xml
@@ -3,7 +3,8 @@
 <plugin>
   <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
     <delegateCommandHandler class="com.shengchen.checkstyle.runner.handler.DelegateCommandHandler">
-    	<command id="java.checkstyle.checkCode"/>
+    	<command id="java.checkstyle.setConfiguration"/>
+      <command id="java.checkstyle.checkCode"/>
     	<command id="java.checkstyle.quickFix"/>
     </delegateCommandHandler>
   </extension>

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class CheckstyleExecutionListener implements AuditListener {
 
@@ -72,8 +70,8 @@ public class CheckstyleExecutionListener implements AuditListener {
     }
 
     public Map<String, List<CheckResult>> getResult(List<String> filesToCheck) {
-        Map<String, List<CheckResult>> result = new HashMap<>();
-        for (String file: filesToCheck) {
+        final Map<String, List<CheckResult>> result = new HashMap<>();
+        for (final String file: filesToCheck) {
             result.put(file, fileErrors.get(file));
         }
         return result;

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class CheckstyleExecutionListener implements AuditListener {
 
@@ -37,9 +39,9 @@ public class CheckstyleExecutionListener implements AuditListener {
             return;
         }
         fileErrors.get(error.getFileName()).add(new CheckResult(
-            error.getLine(), 
-            error.getColumn(), 
-            error.getMessage(), 
+            error.getLine(),
+            error.getColumn(),
+            error.getMessage(),
             severity.toString(),
             error.getSourceName().substring(error.getSourceName().lastIndexOf('.') + 1)));
     }
@@ -69,7 +71,9 @@ public class CheckstyleExecutionListener implements AuditListener {
         return;
     }
 
-    public Map<String, List<CheckResult>> getResult() {
-        return fileErrors;
+    public Map<String, List<CheckResult>> getResult(List<String> filesToCheck) {
+        return filesToCheck.stream()
+            .filter(fileErrors::containsKey)
+            .collect(Collectors.toMap(Function.identity(), fileErrors::get));
     }
 }

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleExecutionListener.java
@@ -72,8 +72,10 @@ public class CheckstyleExecutionListener implements AuditListener {
     }
 
     public Map<String, List<CheckResult>> getResult(List<String> filesToCheck) {
-        return filesToCheck.stream()
-            .filter(fileErrors::containsKey)
-            .collect(Collectors.toMap(Function.identity(), fileErrors::get));
+        Map<String, List<CheckResult>> result = new HashMap<>();
+        for (String file: filesToCheck) {
+            result.put(file, fileErrors.get(file));
+        }
+        return result;
     }
 }

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
@@ -52,15 +52,18 @@ import java.util.stream.Collectors;
 public class CheckstyleRunner {
 
     private static final Checker checker;
+    private static final CheckstyleExecutionListener listener;
 
     static {
         checker = new Checker();
+        listener = new CheckstyleExecutionListener();
 
         // reset the basedir if it is set so it won't get into the plugins way
         // of determining workspace resources from checkstyle reported file names, see
         // https://sourceforge.net/tracker/?func=detail&aid=2880044&group_id=80344&atid=559497
         checker.setBasedir(null);
         checker.setModuleClassLoader(Checker.class.getClassLoader());
+        checker.addListener(listener);
     }
 
     public static void setConfiguration(
@@ -87,14 +90,8 @@ public class CheckstyleRunner {
         final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(filesToCheck.get(0).toURI());
         checker.setCharset(unit.getJavaProject().getProject().getDefaultCharset());
 
-        final CheckstyleExecutionListener listener = new CheckstyleExecutionListener();
-        checker.addListener(listener);
-        try {
-            checker.process(filesToCheck);
-            return listener.getResult();
-        } finally {
-            checker.removeListener(listener);
-        }
+        checker.process(filesToCheck);
+        return listener.getResult(filesToCheckUris);
     }
 
     public static WorkspaceEdit quickFix(

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.text.edits.TextEdit;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.List;
@@ -49,42 +50,51 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("restriction")
 public class CheckstyleRunner {
-    public static Map<String, List<CheckResult>> checkCode(
-        List<String> filesToCheckUris,
+
+    private static final Checker checker;
+
+    static {
+        checker = new Checker();
+
+        // reset the basedir if it is set so it won't get into the plugins way
+        // of determining workspace resources from checkstyle reported file names, see
+        // https://sourceforge.net/tracker/?func=detail&aid=2880044&group_id=80344&atid=559497
+        checker.setBasedir(null);
+        checker.setModuleClassLoader(Checker.class.getClassLoader());
+    }
+
+    public static void setConfiguration(
         String configurationFsPath,
-        Map<String, String> properties            
+        Map<String, String> properties
+    ) throws IOException, CheckstyleException {
+        final Properties checkstyleProperties = new Properties();
+        checkstyleProperties.putAll(properties);
+        checker.configure(ConfigurationLoader.loadConfiguration(
+            configurationFsPath,
+            new PropertiesExpander(checkstyleProperties),
+            IgnoredModulesOptions.OMIT
+        ));
+    }
+
+    public static Map<String, List<CheckResult>> checkCode(
+        List<String> filesToCheckUris
     ) throws UnsupportedEncodingException, CoreException, CheckstyleException {
         if (filesToCheckUris.isEmpty()) {
             return Collections.emptyMap();
         }
-        
-        final List<File> filesToCheck = filesToCheckUris.stream()
-                .map(file -> new File(file))
-                .collect(Collectors.toList());
+        final List<File> filesToCheck = filesToCheckUris.stream().map(File::new).collect(Collectors.toList());
 
-        final Checker checker = new Checker();
-        
         final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(filesToCheck.get(0).toURI());
         checker.setCharset(unit.getJavaProject().getProject().getDefaultCharset());
 
-        // reset the basedir if it is set so it won't get into the plugins way
-        // of determining workspace resources from checkstyle reported file
-        // names, see
-        // https://sourceforge.net/tracker/?func=detail&aid=2880044&group_id=80344&atid=559497
-        checker.setBasedir(null);
-        checker.setModuleClassLoader(Checker.class.getClassLoader());
-        
-        final Properties checkstyleProperties = new Properties();
-        checkstyleProperties.putAll(properties);
-        final Configuration configuration = ConfigurationLoader.loadConfiguration(configurationFsPath,
-                new PropertiesExpander(checkstyleProperties), IgnoredModulesOptions.OMIT);
-        checker.configure(configuration);
-        
         final CheckstyleExecutionListener listener = new CheckstyleExecutionListener();
         checker.addListener(listener);
-        checker.process(filesToCheck);
-
-        return listener.getResult();
+        try {
+            checker.process(filesToCheck);
+            return listener.getResult();
+        } finally {
+            checker.removeListener(listener);
+        }
     }
 
     public static WorkspaceEdit quickFix(

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleRunner.java
@@ -22,7 +22,6 @@ import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.shengchen.checkstyle.runner.quickfix.BaseQuickFix;
 import com.shengchen.checkstyle.runner.utils.EditUtils;
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "onLanguage:java",
         "onCommand:java.checkstyle.quickFix",
         "onCommand:java.checkstyle.checkCode",
-        "onCommand:java.checkstyle.set.configuration"
+        "onCommand:java.checkstyle.setConfiguration"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -48,7 +48,7 @@
                     "group": "Checkstyle@1"
                 },
                 {
-                    "command": "java.checkstyle.set.configuration",
+                    "command": "java.checkstyle.setConfiguration",
                     "when": "!explorerResourceIsFolder && resourceLangId == xml",
                     "group": "Checkstyle@2"
                 }
@@ -61,8 +61,8 @@
                 "category": "Checkstyle"
             },
             {
-                "command": "java.checkstyle.set.configuration",
-                "title": "%contributes.commands.java.checkstyle.set.configuration.title%",
+                "command": "java.checkstyle.setConfiguration",
+                "title": "%contributes.commands.java.checkstyle.setConfiguration.title%",
                 "category": "Checkstyle"
             }
         ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
     "description": "Provide real-time feedback about Checkstyle violations and quick fix actions",
-    "contributes.commands.java.checkstyle.set.configuration.title": "Set the Checkstyle Configuration File",
+    "contributes.commands.java.checkstyle.setConfiguration.title": "Set the Checkstyle Configuration File",
     "contributes.commands.java.checkstyle.checkCode.title": "Check Code with Checkstyle",
     "configuration.java.checkstyle.configuration.description": "Specify the path of the Checkstyle configuration file",
     "configuration.java.checkstyle.properties.description": "Specify the customized properties used in the Checkstyle configuration",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,6 +1,6 @@
 {
     "description": "提供实时的 Checkstyle 代码检测结果，并帮助用户修改代码",
-    "contributes.commands.java.checkstyle.set.configuration.title": "设置 Checkstyle 配置文件",
+    "contributes.commands.java.checkstyle.setConfiguration.title": "设置 Checkstyle 配置文件",
     "contributes.commands.java.checkstyle.checkCode.title": "检查代码",
     "configuration.java.checkstyle.configuration.description": "Checkstyle 配置文件所在路径",
     "configuration.java.checkstyle.properties.description": "自定义 Checkstyle 配置文件中所用到的 Properties",

--- a/src/checkstyleDiagnosticManager.ts
+++ b/src/checkstyleDiagnosticManager.ts
@@ -12,7 +12,6 @@ import { CheckstyleExtensionCommands } from './constants/commands';
 import { FileSynchronizer, SyncedFile } from './features/FileSynchronizer';
 import { ICheckstyleResult } from './models';
 import { handleErrors } from './utils/errorUtils';
-import { getCheckstyleConfigurationPath, getCheckstyleProperties } from './utils/settingUtils';
 
 class CheckstyleDiagnosticManager implements vscode.Disposable {
 
@@ -21,7 +20,7 @@ class CheckstyleDiagnosticManager implements vscode.Disposable {
     private pendingDiagnostics: Set<SyncedFile | vscode.Uri>;
     private syncedFiles: Map<string, SyncedFile>;
     private synchronizer: FileSynchronizer;
-    private diagnosticDelayTrigger: (() => Promise<void>) & _.Cancelable;
+    private diagnosticDelayTrigger: () => Promise<void>;
 
     public initialize(context: vscode.ExtensionContext): void {
         this.context = context;
@@ -31,7 +30,7 @@ class CheckstyleDiagnosticManager implements vscode.Disposable {
         this.synchronizer = new FileSynchronizer(this.context);
     }
 
-    public listen(): void {
+    public startListening(): void {
         if (this.listeners.length > 0) {
             return; // Already started to listen
         }
@@ -46,7 +45,7 @@ class CheckstyleDiagnosticManager implements vscode.Disposable {
         if (this.listeners.length === 0) {
             return; // Already disposed
         }
-        this.diagnosticDelayTrigger = _.debounce(() => Promise.resolve(), 200);
+        this.diagnosticDelayTrigger = async (): Promise<void> => { /* Do nothing */ };
         this.synchronizer.dispose();
         for (const listener of this.listeners) {
             listener.dispose();

--- a/src/commands/setCheckstyleConfiguration.ts
+++ b/src/commands/setCheckstyleConfiguration.ts
@@ -3,8 +3,14 @@
 
 import * as path from 'path';
 import { OpenDialogOptions, QuickPickItem, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { checkstyleChannel } from '../checkstyleChannel';
+import { checkstyleDiagnosticManager } from '../checkstyleDiagnosticManager';
 import { BuiltinConfiguration } from '../constants/BuiltinConfiguration';
-import { setCheckstyleConfigurationPath } from '../utils/settingUtils';
+import { CheckstyleExtensionCommands } from '../constants/commands';
+import { ICheckstyleResult } from '../models';
+import { handleErrors } from '../utils/errorUtils';
+import { getCheckstyleConfigurationPath, getCheckstyleProperties, setCheckstyleConfigurationPath } from '../utils/settingUtils';
+import { executeJavaLanguageServerCommand } from './executeJavaLanguageServerCommand';
 
 export async function setCheckstyleConfiguration(uri?: Uri): Promise<void> {
     if (uri) {
@@ -96,4 +102,24 @@ enum ConfigurationSelction {
     GoogleStyle = "Google's Style",
     SunStyle = "Sun's Style",
     Browse = '$(file-text) Browse...',
+}
+
+export async function setServerConfiguration(): Promise<void> {
+    const configurationPath: string = getCheckstyleConfigurationPath();
+    if (configurationPath === '') {
+        checkstyleChannel.appendLine('Checkstyle configuration file not set yet, skip the check.');
+        checkstyleDiagnosticManager.dispose();
+        return;
+    }
+    try {
+        await executeJavaLanguageServerCommand<{ [file: string]: ICheckstyleResult[] }>(
+            CheckstyleExtensionCommands.SET_CHECKSTYLE_CONFIGURATION,
+            configurationPath,
+            getCheckstyleProperties(),
+        );
+        checkstyleDiagnosticManager.listen();
+    } catch (error) {
+        handleErrors(error);
+        checkstyleDiagnosticManager.dispose();
+    }
 }

--- a/src/commands/setCheckstyleConfiguration.ts
+++ b/src/commands/setCheckstyleConfiguration.ts
@@ -106,7 +106,7 @@ enum ConfigurationSelction {
 
 export async function setServerConfiguration(): Promise<void> {
     const configurationPath: string = getCheckstyleConfigurationPath();
-    if (configurationPath === '') {
+    if (!configurationPath) {
         checkstyleChannel.appendLine('Checkstyle configuration file not set yet, skip the check.');
         checkstyleDiagnosticManager.dispose();
         return;
@@ -117,7 +117,7 @@ export async function setServerConfiguration(): Promise<void> {
             configurationPath,
             getCheckstyleProperties(),
         );
-        checkstyleDiagnosticManager.listen();
+        checkstyleDiagnosticManager.startListening();
     } catch (error) {
         handleErrors(error);
         checkstyleDiagnosticManager.dispose();

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -6,7 +6,7 @@ export namespace JavaLanguageServerCommands {
 }
 
 export namespace CheckstyleExtensionCommands {
-    export const SET_CHECKSTYLE_CONFIGURATION: string = 'java.checkstyle.set.configuration';
+    export const SET_CHECKSTYLE_CONFIGURATION: string = 'java.checkstyle.setConfiguration';
     export const CHECK_CODE_WITH_CHECKSTYLE: string = 'java.checkstyle.checkCode';
     export const FIX_CHECKSTYLE_VIOLATION: string = 'java.checkstyle.quickFix';
     export const OPEN_OUTPUT_CHANNEL: string = 'java.checkstyle.open.output.channel';


### PR DESCRIPTION
## Introduction
* Make checker & listener static
* Add `setConfiguration` command as initialization process;
* Diagnostic manager now disposable, making it possible to skip the check as well as file sync when configuration file not set.