### PR TITLE
fix: Keep the temp file's name the same with original file

### DIFF
--- a/src/features/FileSynchronizer.ts
+++ b/src/features/FileSynchronizer.ts
@@ -160,7 +160,7 @@ export class FileSynchronizer implements vscode.Disposable {
         let tempPath: string | undefined = this.tempFilePool.get(realPath);
         if (!tempPath) {
             const tempHash: string = crypto.createHash('md5').update(realPath).digest('hex');
-            tempPath = path.join(this.tempStorage, `${tempHash}${path.extname(realPath)}`);
+            tempPath = path.join(this.tempStorage, tempHash, path.basename(realPath));
         }
         return tempPath;
     }


### PR DESCRIPTION
Fix #192 by keeping temp file's name the same with original file and saved in a singleton temp folder.