### PR TITLE
chore: Migrate to gulp-remote-src

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,10 +5,10 @@ const gulp = require('gulp');
 const cp = require('child_process');
 const tslint = require('gulp-tslint');
 const decompress = require('gulp-decompress');
-const download = require('gulp-download');
 const path = require('path');
 const fse = require('fs-extra');
 const os = require('os');
+const remoteSrc = require('gulp-remote-src');
 
 const serverDir = path.join(__dirname, 'jdtls.ext');
 const vscodeExtensionsPath = path.join(os.homedir(), '.vscode', 'extensions');
@@ -16,7 +16,7 @@ const vscodeExtensionsPath = path.join(os.homedir(), '.vscode', 'extensions');
 // Build required jar files.
 const checkstyleVersion = '8.18';
 gulp.task('download-checkstyle', (done) => {
-    download(`https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyleVersion}/checkstyle-${checkstyleVersion}-all.jar`)
+    remoteSrc([`checkstyle-${checkstyleVersion}-all.jar`], { base: `https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyleVersion}/` })
         .pipe(gulp.dest(path.join(serverDir, 'com.shengchen.checkstyle.runner', 'lib')))
         .on('end', done);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,12 +766,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"beeper": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-			"dev": true
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1532,12 +1526,6 @@
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
 			"dev": true
 		},
-		"dateformat": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-			"dev": true
-		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1805,41 +1793,6 @@
 			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
-		},
-		"duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.1.9"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
 		},
 		"duplexify": {
 			"version": "3.6.1",
@@ -3391,54 +3344,6 @@
 				}
 			}
 		},
-		"gulp-download": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/gulp-download/-/gulp-download-0.0.1.tgz",
-			"integrity": "sha1-VKMBj8YZs0HM9kkWBvet8L08c5c=",
-			"dev": true,
-			"requires": {
-				"gulp-util": "^3.0.8",
-				"request": "^2.88.0",
-				"request-progress": "^3.0.0",
-				"through": "^2.3.8"
-			},
-			"dependencies": {
-				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-					"dev": true,
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"through": {
-					"version": "2.3.8",
-					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-					"dev": true
-				}
-			}
-		},
 		"gulp-filter": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
@@ -3492,6 +3397,48 @@
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
+			}
+		},
+		"gulp-remote-src": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.4.tgz",
+			"integrity": "sha512-mo7lGgZmNXyTbcUzfjSnUVkx1pnqqiwv/pPaIrYdTO77hq0WNTxXLAzQdoYOnyJ0mfVLNmNl9AGqWLiAzTPMMA==",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"node.extend": "~1.1.2",
+				"request": "^2.88.0",
+				"through2": "~2.0.3",
+				"vinyl": "~2.0.1"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"dev": true
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+					"integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+					"dev": true,
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"is-stream": "^1.1.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -3660,82 +3607,6 @@
 				}
 			}
 		},
-		"gulp-util": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-			"dev": true,
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-uniq": "^1.0.2",
-				"beeper": "^1.0.0",
-				"chalk": "^1.0.0",
-				"dateformat": "^2.0.0",
-				"fancy-log": "^1.1.0",
-				"gulplog": "^1.0.0",
-				"has-gulplog": "^0.1.0",
-				"lodash._reescape": "^3.0.0",
-				"lodash._reevaluate": "^3.0.0",
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.template": "^3.0.0",
-				"minimist": "^1.1.0",
-				"multipipe": "^0.1.2",
-				"object-assign": "^3.0.0",
-				"replace-ext": "0.0.1",
-				"through2": "^2.0.0",
-				"vinyl": "^0.5.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"object-assign": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-					"dev": true,
-					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
-						"replace-ext": "0.0.1"
-					}
-				}
-			}
-		},
 		"gulp-vinyl-zip": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
@@ -3827,15 +3698,6 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
-		},
-		"has-gulplog": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-			"dev": true,
-			"requires": {
-				"sparkles": "^1.0.0"
-			}
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -4489,125 +4351,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
 			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
 		},
-		"lodash._basecopy": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-			"dev": true
-		},
-		"lodash._basetostring": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-			"dev": true
-		},
-		"lodash._basevalues": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-			"dev": true
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-			"dev": true
-		},
-		"lodash._isiterateecall": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-			"dev": true
-		},
-		"lodash._reescape": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-			"dev": true
-		},
-		"lodash._reevaluate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-			"dev": true
-		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
-		},
-		"lodash._root": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-			"dev": true
-		},
-		"lodash.escape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-			"dev": true,
-			"requires": {
-				"lodash._root": "^3.0.0"
-			}
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-			"dev": true
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-			"dev": true
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
-			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
-		},
-		"lodash.restparam": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-			"dev": true
-		},
-		"lodash.template": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-			"dev": true,
-			"requires": {
-				"lodash._basecopy": "^3.0.0",
-				"lodash._basetostring": "^3.0.0",
-				"lodash._basevalues": "^3.0.0",
-				"lodash._isiterateecall": "^3.0.0",
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.escape": "^3.0.0",
-				"lodash.keys": "^3.0.0",
-				"lodash.restparam": "^3.0.0",
-				"lodash.templatesettings": "^3.0.0"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-			"dev": true,
-			"requires": {
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.escape": "^3.0.0"
-			}
-		},
 		"lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4968,15 +4711,6 @@
 				"array-union": "^1.0.1",
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
-			}
-		},
-		"multipipe": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-			"dev": true,
-			"requires": {
-				"duplexer2": "0.0.2"
 			}
 		},
 		"mute-stdout": {
@@ -5879,15 +5613,6 @@
 				"uuid": "^3.3.2"
 			}
 		},
-		"request-progress": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-			"integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
-			"dev": true,
-			"requires": {
-				"throttleit": "^1.0.0"
-			}
-		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6662,12 +6387,6 @@
 					}
 				}
 			}
-		},
-		"throttleit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-			"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "@types/node": "^8.10.25",
         "gulp": "^4.0.0",
         "gulp-decompress": "^2.0.2",
-        "gulp-download": "0.0.1",
+        "gulp-remote-src": "^0.4.4",
         "gulp-tslint": "^8.1.3",
         "native-ext-loader": "^2.3.0",
         "ts-loader": "^5.3.3",


### PR DESCRIPTION
gulp-download is not maintain for a long time. Cause security vulnerability now.