### PR TITLE
fix: BAD uri lacks scheme warning when the config is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the "vscode-checkstyle" extension will be documented in t
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-##[1.2.0]
+## [1.2.0]
 ### Added
 - Open the Problems panel when click the status icon in the status bar. ([#176](https://github.com/jdneo/vscode-checkstyle/issues/176))
 
@@ -104,4 +104,4 @@ Initial release for the new Checkstyle extension, the new extension contains fol
 - Add setting ```checkstyle.autocheck```.
 
 ### Fixed
-- Fix the issue that the checkstyle output may not be correctly parsed. 
+- Fix the issue that the checkstyle output may not be correctly parsed.

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -44,7 +44,7 @@ async function queryForConfiguration(): Promise<string | undefined> {
         },
         {
             label: '$(link) Use URL...',
-            detail: 'Use a Checkstyle file accessible via HTTP.',
+            detail: 'Use a Checkstyle configuration accessible via HTTP.',
             value: ':input',
         },
         {
@@ -81,7 +81,7 @@ async function browseForConfiguration(): Promise<string | undefined> {
 
 async function inputConfiguration(): Promise<string | undefined> {
     const configPath: string | undefined = await window.showInputBox({
-        prompt: 'Enter configuration path here.',
+        prompt: 'Enter configuration URL here.',
         placeHolder: 'Supports http(s)://...',
         value: 'https://',
         ignoreFocusOut: true,


### PR DESCRIPTION
#### configUri handles the case when config.path is empty

`Uri.file` will parse "" to "/".