### PR TITLE
chore: Update typescript version & extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin",
+		"yaozheng.vscode-pde"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,7 @@
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
+    // Use workspace's typescript version to provide correct language service
+    "typescript.tsdk": "node_modules/typescript/lib",
     "java.checkstyle.configuration": "${workspaceFolder}/jdtls.ext/checkstyle.xml"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6613,9 +6613,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+			"integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
 			"dev": true
 		},
 		"unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "native-ext-loader": "^2.3.0",
         "ts-loader": "^5.3.3",
         "tslint": "^5.8.0",
-        "typescript": "^3.1.4",
+        "typescript": "^3.6.2",
         "vscode": "^1.1.25",
         "webpack": "^4.29.0",
         "webpack-cli": "^3.2.1"

--- a/src/checkstyleConfigurationManager.ts
+++ b/src/checkstyleConfigurationManager.ts
@@ -39,7 +39,7 @@ class CheckstyleConfigurationManager implements vscode.Disposable {
     }
     public get isConfigFromLocalFs(): boolean {
         return !!(this.configUri && this.configUri.scheme === 'file'
-            && !Object.values(BuiltinConfiguration).includes(this.config.path));
+            && !(Object.values(BuiltinConfiguration) as string[]).includes(this.config.path));
     }
 
     public onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): void {


### PR DESCRIPTION
For now, the newest typescript version is 3.6.2, where a stricter type deduction is performed. In such case, if a developer globally uses the newer version, the `tsc` command won't pass. 

### Steps to reproduce
Environment:
1. The typescript version specified in package.lock.json is 3.2.2
2. The typescript version used by vscode is 3.5.2
3. The typescript version globally installed is 3.6.2

In such case:
1. TS's language service in vscode uses 3.5.2 (by default, overriden by `typescript.tsdk` setting)
2. package.json's `npm run compile` uses 3.6.2 (no idea why not use version specified in lock).
3. Version 3.6.2 will complain a TypeError, which will pass in 3.5.2.
4. As a result, vscode editor does not complain any error, but project fails to compile.