### PR TITLE
fix: node_modules will be searched when detecting configuration

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -4,6 +4,7 @@
 import * as fse from 'fs-extra';
 import { Uri, window, workspace } from 'vscode';
 import { checkstyleDiagnosticManager } from '../checkstyleDiagnosticManager';
+import { findNonIgnoredFiles } from '../utils/workspaceUtils';
 
 export async function checkCode(uri?: Uri): Promise<void> {
     if (!uri) { // If not specified, check active editor
@@ -14,7 +15,7 @@ export async function checkCode(uri?: Uri): Promise<void> {
     }
     let filesToCheck: Uri[];
     if ((await fse.stat(uri.fsPath)).isDirectory()) {
-        filesToCheck = await workspace.findFiles(`${workspace.asRelativePath(uri)}/**/*.java`);
+        filesToCheck = await findNonIgnoredFiles(`${workspace.asRelativePath(uri)}/**/*.java`);
     } else {
         filesToCheck = [uri];
     }

--- a/src/constants/checkstyleConfigs.ts
+++ b/src/constants/checkstyleConfigs.ts
@@ -7,6 +7,10 @@ export enum BuiltinConfiguration {
 }
 
 export const checkstyleDoctypeIds: string[] = [
+    '-//Checkstyle//DTD Configuration 1.0//EN',
+    '-//Checkstyle//DTD Configuration 1.1//EN',
+    '-//Checkstyle//DTD Configuration 1.2//EN',
+    '-//Checkstyle//DTD Configuration 1.3//EN',
     '-//Checkstyle//DTD Checkstyle Configuration 1.0//EN',
     '-//Checkstyle//DTD Checkstyle Configuration 1.1//EN',
     '-//Checkstyle//DTD Checkstyle Configuration 1.2//EN',

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -1,9 +1,9 @@
 // Copyright (c) jdneo. All rights reserved.
 // Licensed under the GNU LGPLv3 license.
 
-import * as path from 'path';
-import { ConfigurationTarget, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { ConfigurationTarget, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
 import { JAVA_CHECKSTYLE_AUTOCHECK, JAVA_CHECKSTYLE_CONFIGURATION, JAVA_CHECKSTYLE_PROPERTIES, JAVA_CHECKSTYLE_VERSION } from '../constants/settings';
+import { resolveVariables } from './workspaceUtils';
 
 export function setCheckstyleConfigurationPath(fsPath: string, uri?: Uri): void {
     setConfiguration(JAVA_CHECKSTYLE_CONFIGURATION, fsPath, uri);
@@ -31,32 +31,8 @@ export function getCheckstyleProperties(uri?: Uri): object {
     return properties;
 }
 
-export function getDefaultWorkspaceFolder(): WorkspaceFolder | undefined {
-    const workspaceFolders: WorkspaceFolder[] | undefined = workspace.workspaceFolders;
-    if (workspaceFolders === undefined) {
-        return undefined;
-    }
-    if (workspaceFolders.length === 1) {
-        return workspaceFolders[0];
-    }
-    if (window.activeTextEditor) {
-        const activeWorkspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri);
-        return activeWorkspaceFolder;
-    }
-    return undefined;
-}
-
 export function isAutoCheckEnabled(): boolean {
     return getConfiguration().get<boolean>(JAVA_CHECKSTYLE_AUTOCHECK, true);
-}
-
-export function tryUseWorkspaceFolder(fsPath: string): string {
-    const result: string = workspace.asRelativePath(fsPath);
-    if (result === fsPath) {
-        return result;
-    } else {
-        return path.join('${workspaceFolder}', result);
-    }
 }
 
 export function getConfiguration(uri?: Uri): WorkspaceConfiguration {
@@ -68,27 +44,4 @@ function setConfiguration(section: string, value: any, uri?: Uri): void {
         uri = window.activeTextEditor.document.uri;
     }
     getConfiguration(uri).update(section, value, ConfigurationTarget.WorkspaceFolder);
-}
-
-const workspaceRegexp: RegExp = /\$\{workspacefolder\}/i;
-function resolveVariables(value: string, resourceUri?: Uri): string {
-    if (!resourceUri) {
-        if (!window.activeTextEditor) {
-            return value;
-        }
-        resourceUri = window.activeTextEditor.document.uri;
-    }
-    let workspaceFolder: WorkspaceFolder | undefined;
-    if (resourceUri) {
-        workspaceFolder = workspace.getWorkspaceFolder(resourceUri);
-    } else {
-        workspaceFolder = getDefaultWorkspaceFolder();
-    }
-    if (!workspaceFolder) {
-        return value;
-    }
-    if (workspaceRegexp.test(value)) {
-        return value.replace(workspaceRegexp, workspaceFolder.uri.fsPath);
-    }
-    return value;
 }

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -1,0 +1,47 @@
+// Copyright (c) jdneo. All rights reserved.
+// Licensed under the GNU LGPLv3 license.
+
+import * as path from 'path';
+import { Uri, window, workspace, WorkspaceFolder } from 'vscode';
+
+export function getDefaultWorkspaceFolder(): WorkspaceFolder | undefined {
+    const workspaceFolders: WorkspaceFolder[] | undefined = workspace.workspaceFolders;
+    if (workspaceFolders === undefined) {
+        return undefined;
+    }
+    if (workspaceFolders.length === 1) {
+        return workspaceFolders[0];
+    }
+    if (window.activeTextEditor) {
+        const activeWorkspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri);
+        return activeWorkspaceFolder;
+    }
+    return undefined;
+}
+
+export function tryUseWorkspaceFolder(fsPath: string): string {
+    const result: string = workspace.asRelativePath(fsPath);
+    if (result === fsPath) {
+        return result;
+    } else {
+        return path.join('${workspaceFolder}', result);
+    }
+}
+
+const workspaceRegexp: RegExp = /\$\{workspacefolder\}/i;
+
+export function resolveVariables(value: string, resourceUri?: Uri): string {
+    let workspaceFolder: WorkspaceFolder | undefined;
+    if (resourceUri) {
+        workspaceFolder = workspace.getWorkspaceFolder(resourceUri);
+    } else {
+        workspaceFolder = getDefaultWorkspaceFolder();
+    }
+    if (workspaceRegexp.test(value)) {
+        if (!workspaceFolder) {
+            throw Error('workspaceFolder not loaded when ${workspaceFolder} is present');
+        }
+        return value.replace(workspaceRegexp, workspaceFolder.uri.fsPath);
+    }
+    return value;
+}

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -52,14 +52,14 @@ export function resolveVariables(value: string, resourceUri?: Uri): string {
 // workspace.findFiles only defaults to exclude entires in files.exclude
 // so it is not even able to exclude node_modules
 // Refer to: https://github.com/Microsoft/vscode/issues/48674
-export async function findNonIgnoredFiles(pattern: string, checkGitIgnore: boolean = true): Promise<Uri[]> {
+export async function findNonIgnoredFiles(pattern: string): Promise<Uri[]> {
     let uris: Uri[] = await workspace.findFiles(pattern, `{${[
         ...Object.keys(await workspace.getConfiguration('search', null).get('exclude') || {}),
         ...Object.keys(await workspace.getConfiguration('files', null).get('exclude') || {}),
     ].join(',')}}`);
 
     const workspaceFolder: WorkspaceFolder | undefined = getDefaultWorkspaceFolder();
-    if (checkGitIgnore && workspaceFolder) {
+    if (workspaceFolder) {
         try { // tslint:disable-next-line: typedef
             const result: string = await new Promise<string>((resolve, reject) => {
                 cp.exec(`git check-ignore ${uris.map((uri: Uri) => workspace.asRelativePath(uri)).join(' ')}`, {


### PR DESCRIPTION
Fix #242 

`workspace.findFiles` by default will **NOT** exclude `node_modules`, because it only uses `files.exclude` setting, where `node_modules` is in `search.exclude` and `.gitignore`.
 - **reference**: https://github.com/Microsoft/vscode/issues/48674, an problem which is aware of by vscode team
 - **fix**: Introduce a new funciton, excludes all of `files.exclude`, `search.exclude` and `.gitignore`, like https://github.com/Microsoft/vscode/issues/48674#issuecomment-422950502