### PR TITLE
fix: Diagnostic manager should be disabled at the beginning

### DIFF
--- a/src/checkstyleDiagnosticManager.ts
+++ b/src/checkstyleDiagnosticManager.ts
@@ -26,7 +26,7 @@ class CheckstyleDiagnosticManager implements vscode.Disposable {
 
     public initialize(context: vscode.ExtensionContext): void {
         this.context = context;
-        this.enabled = true;
+        this.enabled = false;
         this.listeners = [];
         this.pendingDiagnostics = new Set();
         this.syncedFiles = new Map();


### PR DESCRIPTION
It is to ensure that diagnostic service can only be enabled after configuraiton has been successfully set.