### PR TITLE
fix: setConfiguration request is sent twice every time refreshing

### DIFF
--- a/src/checkstyleConfigurationManager.ts
+++ b/src/checkstyleConfigurationManager.ts
@@ -92,7 +92,7 @@ class CheckstyleConfigurationManager implements vscode.Disposable {
             this.configWatcher = undefined;
         }
         if (this.isConfigFromLocalFs) {
-            this.configWatcher = chokidar.watch(this.config.path);
+            this.configWatcher = chokidar.watch(this.config.path, { ignoreInitial: true });
             this.configWatcher.on('all', (_event: string) => { this.syncServer(); });
         }
     }


### PR DESCRIPTION
It is because everytime refreshing, a new chokidar watcher is set to watch the config file, when a new 'add' event is emitted after intialization, causing a new refresh.

Problems raised by it:
* ConcurrentModificationException
* Error log pop up twice when there's error in module initialization