### PR TITLE
fix: ${workspaceFolder}/.../checkstyle.xml not found

### DIFF
--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -72,22 +72,16 @@ function setConfiguration(section: string, value: any, uri?: Uri): void {
 
 const workspaceRegexp: RegExp = /\$\{workspacefolder\}/i;
 function resolveVariables(value: string, resourceUri?: Uri): string {
-    if (!resourceUri) {
-        if (!window.activeTextEditor) {
-            return value;
-        }
-        resourceUri = window.activeTextEditor.document.uri;
-    }
     let workspaceFolder: WorkspaceFolder | undefined;
     if (resourceUri) {
         workspaceFolder = workspace.getWorkspaceFolder(resourceUri);
     } else {
         workspaceFolder = getDefaultWorkspaceFolder();
     }
-    if (!workspaceFolder) {
-        return value;
-    }
     if (workspaceRegexp.test(value)) {
+        if (!workspaceFolder) {
+            throw new Error('No workspace folder is opened in current VS Code workspace when resolving ${workspaceFolder}');
+        }
         return value.replace(workspaceRegexp, workspaceFolder.uri.fsPath);
     }
     return value;


### PR DESCRIPTION
The cause: `resolveVariables` should not provide default value for resourceUri.