### PR TITLE
refactor: Checkstyle server stability

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
@@ -55,10 +55,14 @@ public class CheckerService implements ICheckerService {
     }
 
     public void dispose() {
-        checker.removeListener(listener);
-        checker.destroy();
-        checker = null;
-        listener = null;
+        if (checker != null) {
+            if (listener != null) {
+                checker.removeListener(listener);
+                listener = null;
+            }
+            checker.destroy();
+            checker = null;
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -85,9 +89,7 @@ public class CheckerService implements ICheckerService {
         } catch (UnsupportedEncodingException | CoreException e) {
             e.printStackTrace();
         }
-        synchronized (checker) {
-            checker.process(filesToCheck);
-        }
+        checker.process(filesToCheck);
         return listener.getResult(filesToCheckUris);
     }
 }

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/DelegateCommandHandler.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/DelegateCommandHandler.java
@@ -42,7 +42,11 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
     private IQuickFixService quickfixService = null;
 
     @Override
-    public Object executeCommand(String commandId, List<Object> arguments, IProgressMonitor monitor) throws Exception {
+    public synchronized Object executeCommand(
+        String commandId,
+        List<Object> arguments,
+        IProgressMonitor monitor
+    ) throws Exception {
         if (commandId.startsWith(CHECKSTYLE_PREFIX)) { // Only handle commands with specific id prefix
             final String command = commandId.substring(CHECKSTYLE_PREFIX.length()); // Remove prefix as handler name
             for (final Method handler : this.getClass().getDeclaredMethods()) {
@@ -54,7 +58,7 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
         return null;
     }
 
-    public void setConfiguration(Map<String, Object> config) throws Exception {
+    protected void setConfiguration(Map<String, Object> config) throws Throwable {
         final String jarStorage = (String) config.get("jarStorage");
         final String version = (String) config.get("version");
         final String jarPath = String.format("%s/checkstyle-%s-all.jar", jarStorage, version);
@@ -64,25 +68,31 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
         if (!version.equals(getVersion())) { // If not equal, load new version
             checkerService = checkstyleLoader.loadCheckerService(jarPath);
         }
-        checkerService.initialize();
-        checkerService.setConfiguration(config);
+        try {
+            checkerService.initialize();
+            checkerService.setConfiguration(config);
+        } catch (Throwable throwable) { // Initialization faild
+            checkerService.dispose(); // Unwind what's already initialized
+            checkerService = null;    // Remove checkerService
+            throw throwable;          // Resend the exception or error out
+        }
     }
 
-    public String getVersion() throws Exception {
+    protected String getVersion() throws Exception {
         if (checkerService != null) {
             return checkerService.getVersion();
         }
         return null;
     }
 
-    public Map<String, List<CheckResult>> checkCode(List<String> filesToCheckUris) throws Exception {
+    protected Map<String, List<CheckResult>> checkCode(List<String> filesToCheckUris) throws Exception {
         if (filesToCheckUris.isEmpty() || checkerService == null) {
             return Collections.emptyMap();
         }
         return checkerService.checkCode(filesToCheckUris);
     }
 
-    public WorkspaceEdit quickFix(
+    protected WorkspaceEdit quickFix(
         String fileToCheckUri,
         Double offset,
         String sourceName


### PR DESCRIPTION
Some efforts are put to improve the stabillity of checkstyle server:
* dispose guarantees success no matter whether checker or listener is null
* delegate command handler is now synchronied per-request-scale
* checkerService will be set to null upon initialization failed, indicating that currently server cannot provide checkstyle realated service:
   * `getVersion` will return null
   * `checkCode` will return empty map
   * Intialized checker will be disposed to prevent memory leak

Other changes:
* every command handler is now set protected rather than public