### PR TITLE
perf: Use local api data first to provide version information

### DIFF
--- a/src/checkstyleConfigurationManager.ts
+++ b/src/checkstyleConfigurationManager.ts
@@ -80,7 +80,7 @@ class CheckstyleConfigurationManager implements vscode.Disposable {
         const apiUrl: string = `https://api.github.com/repos/checkstyle/checkstyle${api}`;
         async function ensureLatestApiData(location: vscode.ProgressLocation): Promise<T> {
             return await vscode.window.withProgress({
-                location, title: `Fetching checkstyle's github api ${api}...`,
+                location, title: `Fetching Checkstyle metadata (${api})...`,
             }, async (_progress: vscode.Progress<{}>, _token: vscode.CancellationToken) => {
                 const response: Response = await fetch(apiUrl, { timeout: 30000 });
                 const apiData: T = await response.json();
@@ -133,7 +133,7 @@ class CheckstyleConfigurationManager implements vscode.Disposable {
         if (!await fse.pathExists(jarPath)) { // Ensure specified version downloaded on disk
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
-                title: `Downloading checkstyle dependency for version ${version}...`,
+                title: `Downloading Checkstyle dependency for version ${version}...`,
                 cancellable: true, // tslint:disable-next-line: typedef
             }, async (progress, token: vscode.CancellationToken) => {
                 await fse.ensureDir(this.context.globalStoragePath);

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -20,7 +20,7 @@ async function queryForVersion(): Promise<string | undefined> {
         ...await getRecommendedVersions(),
         {
             label: '$(file-text) All supported versions...',
-            detail: 'List all the checkstyle versions supported by extension.',
+            detail: 'List all the Checkstyle versions supported by extension.',
             value: ':list',
         },
     ], { ignoreFocusOut: true });

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -2,7 +2,6 @@
 // Licensed under the GNU LGPLv3 license.
 
 import * as _ from 'lodash';
-import fetch, { Response } from 'node-fetch';
 import { window } from 'vscode';
 import { checkstyleConfigurationManager } from '../checkstyleConfigurationManager';
 import { IQuickPickItemEx } from '../models';
@@ -60,13 +59,12 @@ async function getRecommendedVersions(): Promise<IQuickPickItemEx[]> {
 }
 
 async function getLatestVersion(): Promise<string> {
-    const response: Response = await fetch('https://api.github.com/repos/checkstyle/checkstyle/releases/latest');
-    return (await response.json()).tag_name.match(/checkstyle-([\d.]+)/)![1];
+    const { tag_name } = await checkstyleConfigurationManager.fetchApiData<{ tag_name: string }>('/releases/latest');
+    return tag_name.match(/checkstyle-([\d.]+)/)![1];
 }
 
 async function getAllSupportedVersions(): Promise<string[]> {
-    const response: Response = await fetch('https://api.github.com/repos/checkstyle/checkstyle/git/refs/tags');
-    const tags: Array<{ ref: string }> = await response.json();
+    const tags: Array<{ ref: string }> = await checkstyleConfigurationManager.fetchApiData('/git/refs/tags');
     const versions: string[] = [];
     for (const { ref } of tags) {
         const match: RegExpMatchArray | null = ref.match(/checkstyle-([\d.]+)/);


### PR DESCRIPTION
Fix #227 

Now the `setVersion` command's getting latest version and list all versions functionality will try to use github api data from local disk, and secretly update the data once fetched. If not exist on local disk, then fetch from github and save.