### PR TITLE
fix: Java project with no .classpath file will result in NullPointerException

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
@@ -25,7 +25,6 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.shengchen.checkstyle.runner.api.CheckResult;
 import com.shengchen.checkstyle.runner.api.ICheckerService;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
@@ -25,8 +25,8 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.shengchen.checkstyle.runner.api.CheckResult;
 import com.shengchen.checkstyle.runner.api.ICheckerService;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 
 import java.io.File;
@@ -83,13 +83,9 @@ public class CheckerService implements ICheckerService {
 
     public Map<String, List<CheckResult>> checkCode(List<String> filesToCheckUris) throws CheckstyleException {
         final List<File> filesToCheck = filesToCheckUris.stream().map(File::new).collect(Collectors.toList());
-        final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(filesToCheck.get(0).toURI());
+        final IFile resource = JDTUtils.findFile(filesToCheck.get(0).toURI().toString());
         try {
-            if (unit != null) {
-                checker.setCharset(unit.getResource().getProject().getDefaultCharset());
-            } else { // File is not in a java project
-                checker.setCharset(JDTUtils.findFile(filesToCheck.get(0).toURI().toString()).getCharset());
-            }
+            checker.setCharset(resource != null ? resource.getCharset() : "utf8");
         } catch (UnsupportedEncodingException | CoreException e) {
             e.printStackTrace();
         }

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/checker/CheckerService.java
@@ -25,8 +25,8 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.shengchen.checkstyle.runner.api.CheckResult;
 import com.shengchen.checkstyle.runner.api.ICheckerService;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 
 import java.io.File;
@@ -83,9 +83,12 @@ public class CheckerService implements ICheckerService {
 
     public Map<String, List<CheckResult>> checkCode(List<String> filesToCheckUris) throws CheckstyleException {
         final List<File> filesToCheck = filesToCheckUris.stream().map(File::new).collect(Collectors.toList());
-        final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(filesToCheck.get(0).toURI());
+        IFile resource = JDTUtils.findFile(filesToCheck.get(0).toURI().toString());
+        if (resource == null) { // Resource not in a java project, create a fake one by resolveCompilationUnit
+            resource = (IFile) JDTUtils.resolveCompilationUnit(filesToCheck.get(0).toURI()).getResource();
+        }
         try {
-            checker.setCharset(unit.getJavaProject().getProject().getDefaultCharset());
+            checker.setCharset(resource.getProject().getDefaultCharset());
         } catch (UnsupportedEncodingException | CoreException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Fix #245 

This is because the project with no .classpath will not be recognized as JavaProject in `resolveCompilationUnit` and null is returned. We could directly use `findFile` to get the project.

~~However `resolveCompilationUnit` should still be preserved, as the temp file is not in a project and `findFile` will also return null, while `resolveCompilationUnit` will create a fake one for it.~~
`resolveCompilationUnit` is completely removed now.