### PR TITLE
fix: Plugin jar load failed when jar path containing whitespace

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleLoader.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleLoader.java
@@ -50,7 +50,7 @@ public class CheckstyleLoader {
     }
 
     private String getServerDir() throws Exception {
-        final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+        final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getFile());
         return jarFile.getParentFile().getCanonicalPath();
     }
 }


### PR DESCRIPTION
Fix #253