### PR TITLE
feat: Support third-party extension checkstyle modules

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleLoader.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/CheckstyleLoader.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CheckstyleLoader {
 
@@ -33,14 +35,17 @@ public class CheckstyleLoader {
 
     URLClassLoader checkerClassLoader = null;
 
-    public ICheckerService loadCheckerService(String checkerJarPath) throws Exception {
+    public ICheckerService loadCheckerService(String checkstyleJarPath, List<String> modulejarPaths) throws Exception {
         if (checkerClassLoader != null) {
             checkerClassLoader.close();
         }
-        checkerClassLoader = new URLClassLoader(new URL[] {
-            Paths.get(getServerDir(), "com.shengchen.checkstyle.checker.jar").toUri().toURL(),
-            Paths.get(checkerJarPath).toUri().toURL()
-        }, getClass().getClassLoader());
+        final ArrayList<URL> jarUrls = new ArrayList<>();
+        jarUrls.add(Paths.get(getServerDir(), "com.shengchen.checkstyle.checker.jar").toUri().toURL());
+        jarUrls.add(Paths.get(checkstyleJarPath).toUri().toURL());
+        for (final String module: modulejarPaths) {
+            jarUrls.add(Paths.get(module).toUri().toURL());
+        }
+        checkerClassLoader = new URLClassLoader(jarUrls.toArray(new URL[0]), getClass().getClassLoader());
         final Constructor<?> constructor = checkerClassLoader.loadClass(checkerClass).getConstructor();
         return (ICheckerService) constructor.newInstance();
     }

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/DelegateCommandHandler.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/runner/DelegateCommandHandler.java
@@ -62,15 +62,17 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     protected void setConfiguration(Map<String, Object> config) throws Throwable {
         final String jarStorage = (String) config.get("jarStorage");
         final String version = (String) config.get("version");
         final String jarPath = String.format("%s/checkstyle-%s-all.jar", jarStorage, version);
+        final List<String> modules = (List<String>) config.get("modules");
         if (checkerService != null) {
             checkerService.dispose();
         }
         if (!version.equals(getVersion())) { // If not equal, load new version
-            checkerService = checkstyleLoader.loadCheckerService(jarPath);
+            checkerService = checkstyleLoader.loadCheckerService(jarPath, modules);
         }
         try {
             checkerService.initialize();

--- a/package.json
+++ b/package.json
@@ -90,6 +90,12 @@
                     "default": "8.18",
                     "scope": "resource"
                 },
+                "java.checkstyle.modules": {
+                    "type": "array",
+                    "description": "%configuration.java.checkstyle.modules.description%",
+                    "default": [],
+                    "scope": "resource"
+                },
                 "java.checkstyle.autocheck": {
                     "type": "boolean",
                     "description": "%configuration.java.checkstyle.autocheck.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,6 +5,7 @@
     "contributes.commands.java.checkstyle.checkCode.title": "Check Code with Checkstyle",
     "configuration.java.checkstyle.configuration.description": "Specify the path of the Checkstyle configuration file",
     "configuration.java.checkstyle.version.description": "Specify the version of Checkstyle",
+    "configuration.java.checkstyle.modules.description": "Specify the third-party modules used for Checkstyle",
     "configuration.java.checkstyle.properties.description": "Specify the customized properties used in the Checkstyle configuration",
     "configuration.java.checkstyle.autocheck.description": "Specify if the extension will check the format automatically or not"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -5,6 +5,7 @@
     "contributes.commands.java.checkstyle.checkCode.title": "检查代码",
     "configuration.java.checkstyle.configuration.description": "Checkstyle 配置文件所在路径",
     "configuration.java.checkstyle.version.description": "使用的 Checkstyle 版本",
+    "configuration.java.checkstyle.modules.description": "使用的第三方 Checkstyle 模块",
     "configuration.java.checkstyle.properties.description": "自定义 Checkstyle 配置文件中所用到的 Properties",
     "configuration.java.checkstyle.autocheck.description": "是否启用自动检查"
 }

--- a/src/checkstyleConfigurationManager.ts
+++ b/src/checkstyleConfigurationManager.ts
@@ -15,7 +15,7 @@ import { CheckstyleServerCommands } from './constants/commands';
 import { JAVA_CHECKSTYLE_CONFIGURATIONS, JAVA_CHECKSTYLE_VERSION } from './constants/settings';
 import { ICheckstyleConfiguration } from './models';
 import { handleErrors } from './utils/errorUtils';
-import { getCheckstyleConfigurationPath, getCheckstyleProperties, getCheckstyleVersionString, getConfiguration, setCheckstyleVersionString, getCheckstyleExtensionModules } from './utils/settingUtils';
+import { getCheckstyleConfigurationPath, getCheckstyleExtensionModules, getCheckstyleProperties, getCheckstyleVersionString, getConfiguration, setCheckstyleVersionString } from './utils/settingUtils';
 
 class CheckstyleConfigurationManager implements vscode.Disposable {
 

--- a/src/checkstyleConfigurationManager.ts
+++ b/src/checkstyleConfigurationManager.ts
@@ -15,7 +15,7 @@ import { CheckstyleServerCommands } from './constants/commands';
 import { JAVA_CHECKSTYLE_CONFIGURATIONS, JAVA_CHECKSTYLE_VERSION } from './constants/settings';
 import { ICheckstyleConfiguration } from './models';
 import { handleErrors } from './utils/errorUtils';
-import { getCheckstyleConfigurationPath, getCheckstyleProperties, getCheckstyleVersionString, getConfiguration, setCheckstyleVersionString } from './utils/settingUtils';
+import { getCheckstyleConfigurationPath, getCheckstyleProperties, getCheckstyleVersionString, getConfiguration, setCheckstyleVersionString, getCheckstyleExtensionModules } from './utils/settingUtils';
 
 class CheckstyleConfigurationManager implements vscode.Disposable {
 
@@ -109,6 +109,7 @@ class CheckstyleConfigurationManager implements vscode.Disposable {
             version: getCheckstyleVersionString(),
             path: getCheckstyleConfigurationPath(),
             properties: getCheckstyleProperties(),
+            modules: getCheckstyleExtensionModules(),
         };
         if (this.config.version !== this.getBuiltinVersion()) {
             this.jarStorage = this.context.globalStoragePath;

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -5,8 +5,10 @@ export const JAVA_CHECKSTYLE_AUTOCHECK: string = 'java.checkstyle.autocheck';
 export const JAVA_CHECKSTYLE_CONFIGURATION: string = 'java.checkstyle.configuration';
 export const JAVA_CHECKSTYLE_PROPERTIES: string = 'java.checkstyle.properties';
 export const JAVA_CHECKSTYLE_VERSION: string = 'java.checkstyle.version';
+export const JAVA_CHECKSTYLE_MODULES: string = 'java.checkstyle.modules';
 export const JAVA_CHECKSTYLE_CONFIGURATIONS: string[] = [
     JAVA_CHECKSTYLE_CONFIGURATION,
     JAVA_CHECKSTYLE_PROPERTIES,
     JAVA_CHECKSTYLE_VERSION,
+    JAVA_CHECKSTYLE_MODULES,
 ];

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,4 +18,5 @@ export interface ICheckstyleConfiguration {
     version: string;
     path: string;
     properties: object;
+    modules: string[];
 }

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the GNU LGPLv3 license.
 
 import { ConfigurationTarget, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
-import { JAVA_CHECKSTYLE_AUTOCHECK, JAVA_CHECKSTYLE_CONFIGURATION, JAVA_CHECKSTYLE_PROPERTIES, JAVA_CHECKSTYLE_VERSION } from '../constants/settings';
+import { JAVA_CHECKSTYLE_AUTOCHECK, JAVA_CHECKSTYLE_CONFIGURATION, JAVA_CHECKSTYLE_PROPERTIES, JAVA_CHECKSTYLE_VERSION, JAVA_CHECKSTYLE_MODULES } from '../constants/settings';
 import { resolveVariables } from './workspaceUtils';
 
 export function setCheckstyleConfigurationPath(fsPath: string, uri?: Uri): void {
@@ -21,6 +21,11 @@ export function setCheckstyleVersionString(version: string, uri?: Uri): void {
 export function getCheckstyleVersionString(uri?: Uri): string {
     const version: string = getConfiguration(uri).get<string>(JAVA_CHECKSTYLE_VERSION)!;
     return resolveVariables(version, uri);
+}
+
+export function getCheckstyleExtensionModules(uri?: Uri): string[] {
+    const modules: string[] = getConfiguration(uri).get<string[]>(JAVA_CHECKSTYLE_MODULES)!;
+    return modules.map((mod: string) => resolveVariables(mod, uri));
 }
 
 export function getCheckstyleProperties(uri?: Uri): object {

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the GNU LGPLv3 license.
 
 import { ConfigurationTarget, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
-import { JAVA_CHECKSTYLE_AUTOCHECK, JAVA_CHECKSTYLE_CONFIGURATION, JAVA_CHECKSTYLE_PROPERTIES, JAVA_CHECKSTYLE_VERSION, JAVA_CHECKSTYLE_MODULES } from '../constants/settings';
+import { JAVA_CHECKSTYLE_AUTOCHECK, JAVA_CHECKSTYLE_CONFIGURATION, JAVA_CHECKSTYLE_MODULES, JAVA_CHECKSTYLE_PROPERTIES, JAVA_CHECKSTYLE_VERSION } from '../constants/settings';
 import { resolveVariables } from './workspaceUtils';
 
 export function setCheckstyleConfigurationPath(fsPath: string, uri?: Uri): void {


### PR DESCRIPTION
Fix #206 

Example usage:
```json
    "java.checkstyle.modules": [
        "${workspaceFolder}/src/main/resources/sevntu-checks-1.35.0.jar"
    ]
```

Add `<module name="SingleBreakOrContinueCheck"/>` or `<module name="com.github.sevntu.checkstyle.checks.naming.SingleBreakOrContinueCheck"/>` to `checkstyle.xml`, effect:
![image](https://user-images.githubusercontent.com/20227484/66495102-4eb1cc80-eaeb-11e9-82e6-a02a7ce2a4e8.png)
