### PR TITLE
Fix the error column that’s reported to VS Code

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.checker/src/main/java/com/shengchen/checkstyle/checker/CheckerListener.java
+++ b/jdtls.ext/com.shengchen.checkstyle.checker/src/main/java/com/shengchen/checkstyle/checker/CheckerListener.java
@@ -40,7 +40,7 @@ public class CheckerListener implements AuditListener {
         }
         fileErrors.get(error.getFileName()).add(new CheckResult(
             error.getLine(),
-            error.getColumn(),
+            error.getLocalizedMessage().getColumnCharIndex(),
             error.getMessage(),
             severity.toString().toLowerCase(),
             error.getSourceName().substring(error.getSourceName().lastIndexOf('.') + 1)));

--- a/jdtls.ext/com.shengchen.checkstyle.checker/src/main/java/com/shengchen/checkstyle/checker/CheckerListener.java
+++ b/jdtls.ext/com.shengchen.checkstyle.checker/src/main/java/com/shengchen/checkstyle/checker/CheckerListener.java
@@ -40,7 +40,7 @@ public class CheckerListener implements AuditListener {
         }
         fileErrors.get(error.getFileName()).add(new CheckResult(
             error.getLine(),
-            error.getLocalizedMessage().getColumnCharIndex(),
+            error.getLocalizedMessage().getColumnCharIndex() + 1,
             error.getMessage(),
             severity.toString().toLowerCase(),
             error.getSourceName().substring(error.getSourceName().lastIndexOf('.') + 1)));


### PR DESCRIPTION
This fixes the reported column of errors in VS Code in code that uses tab indentation.

CheckStyle has funny treatment of tabs. Its error.getColumn() returns a number that treats tabs as being however many spaces. Fortunately getolumnCharIndex() returns the correct value to send back to VS Code.