### PR TITLE
Add whitespace check capability and ParenPadQuickFix

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/BaseEditQuickFix.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/BaseEditQuickFix.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) jdneo
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.shengchen.checkstyle.quickfix;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.text.edits.TextEdit;
+
+public abstract class BaseEditQuickFix implements IQuickFix {
+    
+    public abstract TextEdit createTextEdit(IRegion lineInfo, int markerStartOffset, Document doc);
+    
+}

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/BaseQuickFix.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/BaseQuickFix.java
@@ -24,7 +24,7 @@ import org.eclipse.jface.text.IRegion;
 
 import java.util.List;
 
-public abstract class BaseQuickFix {
+public abstract class BaseQuickFix implements IQuickFix {
     public abstract ASTVisitor getCorrectingASTVisitor(IRegion lineInfo, int markerStartOffset);
 
     /**

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/FixableCheck.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/FixableCheck.java
@@ -33,6 +33,9 @@ public enum FixableCheck {
     // Modifier
     MODIFIER_ORDER_CHECK("ModifierOrderCheck"), REDUNDANT_MODIFIER_CHECK("RedundantModifierCheck"),
 
+    // Whitespace
+    PAREN_PAD_CHECK("ParenPadCheck"),
+
     // Misc
     FINAL_PARAMETERS_CHECK("FinalParametersCheck"), UNCOMMENTED_MAIN_CHECK("UncommentedMainCheck"),
     UPPER_ELL_CHECK("UpperEllCheck"), ARRAY_TYPE_STYLE_CHECK("ArrayTypeStyleCheck");

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/IQuickFix.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/IQuickFix.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) jdneo
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.shengchen.checkstyle.quickfix;
+
+public interface IQuickFix {
+
+}

--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/whitepace/ParenPadQuickFix.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/whitepace/ParenPadQuickFix.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) jdneo
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.shengchen.checkstyle.quickfix.whitepace;
+
+import com.shengchen.checkstyle.quickfix.BaseEditQuickFix;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.text.edits.DeleteEdit;
+import org.eclipse.text.edits.TextEdit;
+
+public class ParenPadQuickFix extends BaseEditQuickFix {
+
+    @Override
+    public TextEdit createTextEdit(IRegion lineInfo, int markerStartOffset, Document doc) {
+        try {
+            final int fromStartOfLine = markerStartOffset - lineInfo.getOffset();
+            final char marker = doc.getChar(markerStartOffset);
+            if (marker == '(') {
+                final String string = doc.get(markerStartOffset + 1, lineInfo.getLength() - fromStartOfLine - 1);
+                final int leadingWhitespace = measureLeadingWhitespace(string);
+                if (leadingWhitespace > 0) {
+                    return new DeleteEdit(markerStartOffset + 1, leadingWhitespace);
+                }
+            } else if (marker == ')' && fromStartOfLine > 0) {
+                final String string = doc.get(lineInfo.getOffset(), fromStartOfLine);
+                final int trailingWhitespace = measureTrailingWhitespace(string);
+                if (trailingWhitespace > 0) {
+                    return new DeleteEdit(markerStartOffset - trailingWhitespace, trailingWhitespace);
+                }
+            }
+
+            return null;
+        } catch (BadLocationException e) {
+            return null;
+        }
+    }
+
+    private int measureLeadingWhitespace(String string) {
+        final int n = string.length();
+        for (int i = 0; i < n; i++) {
+            if (!Character.isWhitespace(string.charAt(i))) {
+                return i;
+            }
+        }
+        return n;
+    }
+
+    private int measureTrailingWhitespace(String string) {
+        final int n = string.length();
+        for (int i = n - 1; i >= 0; i--) {
+            if (!Character.isWhitespace(string.charAt(i))) {
+                return n - 1 - i;
+            }
+        }
+        return n;
+    }
+
+}

--- a/src/constants/quickFix.ts
+++ b/src/constants/quickFix.ts
@@ -24,6 +24,9 @@ export enum FixableCheck {
     ModifierOrderCheck = 'ModifierOrderCheck',
     RedundantModifierCheck = 'RedundantModifierCheck',
 
+    // Whitespace
+    ParenPadCheck = 'ParenPadCheck',
+
     // Misc
     FinalParametersCheck = 'FinalParametersCheck',
     UncommentedMainCheck = 'UncommentedMainCheck',


### PR DESCRIPTION
I've had to introduce a new quick fix type. I've tried to minimise the changes, but perhaps `BaseQuickFix` should be renamed to `BaseASTQuickFix`.

(I've also implemented this for the fix all, but I'll add that if / when we merge fix all)