### PR TITLE
Remove redundant modifiers on interface declarations

### DIFF
--- a/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/modifier/RedundantModifierQuickFix.java
+++ b/jdtls.ext/com.shengchen.checkstyle.runner/src/main/java/com/shengchen/checkstyle/quickfix/modifier/RedundantModifierQuickFix.java
@@ -45,6 +45,21 @@ public class RedundantModifierQuickFix extends BaseQuickFix {
         return new ASTVisitor() {
 
             @SuppressWarnings("unchecked")
+            public boolean visit(TypeDeclaration node) {
+                if (containsPosition(node, markerStartOffset)) {
+                    List<ModifierKeyword> redundantKeyWords = Collections.emptyList();
+
+                    if (node.isInterface()) {
+                        redundantKeyWords = Arrays.asList(new ModifierKeyword[] { ModifierKeyword.ABSTRACT_KEYWORD,
+                            ModifierKeyword.STATIC_KEYWORD });
+                    }
+
+                    deleteRedundantModifiers(node.modifiers(), redundantKeyWords);
+                }
+                return true;
+            }
+
+            @SuppressWarnings("unchecked")
             @Override
             public boolean visit(MethodDeclaration node) {
 


### PR DESCRIPTION
Particularly, remove `static` on inner `interface` definitions. But doesn't hurt to remove `abstract` on interfaces too!

(I'm on a mission to quick fix as many issues as possible in a large code base!)